### PR TITLE
Fix deprecation warning about  rdoc

### DIFF
--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/attr-encrypted/attr_encrypted'
   s.license = 'MIT'
 
-  s.rdoc_options = ['--line-numbers', '--inline-source', '--main', 'README.rdoc']
-
   s.require_paths = ['lib']
 
   s.files      = `git ls-files`.split("\n")


### PR DESCRIPTION
Hey guys

This PR fixes this deprecation warning inside `attr_encrypted`'s gemspec file.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from .../attr_encrypted-f81f51520292/attr_encrypted.gemspec:22.
```

This change was added in this RubyGems API changes: https://blog.rubygems.org/2009/05/04/1.3.3-released.html

Please, take a look. Thanks!

