### PR TITLE
Attributes opt into key rotation

### DIFF
--- a/test/key_rotation_test.rb
+++ b/test/key_rotation_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+# encoding: UTF-8
+
+require_relative 'test_helper'
+
+class KeyRotationTest < Minitest::Test
+  class FakeRotatable
+    extend AttrEncrypted
+
+    self.attr_encrypted_options[:mode] = :single_iv_and_salt
+
+    def initialize(value: nil)
+      self.value = value
+    end
+
+    attr_accessor(
+      :value,
+    )
+  end
+
+  def setup
+    @old_config = generate_attr_encrypted_config
+    @new_config = generate_attr_encrypted_config
+
+    FakeRotatable.class_eval do
+      attr_encrypted(
+        :value,
+        *@old_config,
+      )
+    end
+  end
+
+  def teardown
+    Object.send(:remove_const, :FakeRotatable) if Object.const_defined?("FakeRotatable")
+  end
+
+  def test_decrypt_error_while_not_rotataing_keys_raises_cipher_error
+    original = instance_with_attr_encrypted_config(@old_config)
+    original.value = "cleartext-value"
+
+    with_wrong_key = instance_with_attr_encrypted_config(@new_config)
+    with_wrong_key.encrypted_value = original.encrypted_value
+
+    assert_raises(OpenSSL::Cipher::CipherError, "expected OpenSSL::Cipher::CipherError was not raised") do
+      with_wrong_key.value
+    end
+  end
+
+  def test_decrypt_error_when_rotating_keys_retries_with_the_old_key
+    original = instance_with_attr_encrypted_config(@old_config)
+    original.value = "cleartext-value"
+    rotation_handler_instance = Minitest::Mock.new
+    rotation_handler_instance.expect(:call, true)
+
+    rotating = setup_key_rotation(
+      from_config: @old_config,
+      to_config: @new_config,
+      rotation_handler: mock_rotation_handler_class(instance: rotation_handler_instance)
+    )
+
+    assert "cleartext_value", rotating.value
+  end
+
+  def test_rotation_invokes_the_rotation_handler
+    original = instance_with_attr_encrypted_config(@old_config)
+    original.value = "cleartext-value"
+    rotation_handler_instance = Minitest::Mock.new
+    rotation_handler_instance.expect(:call, true)
+
+    rotating = setup_key_rotation(
+      from_config: @old_config,
+      to_config: @new_config,
+      rotation_handler: mock_rotation_handler_class(instance: rotation_handler_instance)
+    )
+    rotating.value
+
+    rotation_handler_instance.verify
+  end
+
+  def test_rotation_invokes_the_rotation_error_handler_when_rotation_fails
+    rotation_handler_instance = Minitest::Mock.new
+    rotation_handler_instance.expect(:call, true)
+    rotation_error_handler_instance = Minitest::Mock.new
+    rotation_error_handler_instance.expect(:call, true)
+    wrong_key = generate_key
+    original = instance_with_attr_encrypted_config(@old_config)
+    original.value = "cleartext-value"
+    rotating = setup_key_rotation(
+      from_config: @old_config.merge(key: wrong_key),
+      to_config: @new_config,
+      rotation_handler: mock_rotation_handler_class(instance: rotation_handler_instance),
+      rotation_error_handler: mock_rotation_error_handler_class(instance: rotation_error_handler_instance)
+    )
+    rotating.encrypted_value = original.encrypted_value
+
+    rotating.value
+
+    rotation_error_handler_instance.verify
+  end
+
+  def instance_with_attr_encrypted_config(key: generate_key, iv: generate_iv)
+    FakeRotatable.class_eval do
+      attr_encrypted(
+        :value,
+        key: key,
+        iv: iv,
+      )
+    end
+
+    FakeRotatable.new
+  end
+
+  def setup_key_rotation(from_config: @old_config, to_config: @new_config, rotation_handler: proc {}, rotation_error_handler: proc {})
+    original = instance_with_attr_encrypted_config(from_config)
+    original.value = "cleartext-value"
+    FakeRotatable.class_eval do
+      attr_encrypted(
+        :value,
+        key: to_config.fetch(:key),
+        iv: to_config.fetch(:iv),
+        old_key: from_config.fetch(:key),
+        old_iv: from_config.fetch(:iv),
+        rotation_handler: rotation_handler,
+        rotation_error_handler: rotation_error_handler,
+      )
+    end
+    rotating = FakeRotatable.new
+    rotating.encrypted_value = original.encrypted_value
+
+    rotating
+  end
+
+  def generate_attr_encrypted_config(key: generate_key, iv: generate_iv)
+    {
+      key: key,
+      iv: iv,
+    }
+  end
+
+  def generate_key
+    SecureRandom.random_bytes(32)
+  end
+
+  def generate_iv
+    SecureRandom.random_bytes(12)
+  end
+
+  def mock_rotation_handler_class(instance:)
+    mock_rotation_handler_class = Minitest::Mock.new
+    mock_rotation_handler_class.expect(:new, instance, [FakeRotatable, :value, "cleartext-value", String, Hash])
+    mock_rotation_handler_class.expect(:!, false) # For presence checks
+    3.times { mock_rotation_handler_class.expect(:is_a?, false, [Symbol]) }
+
+    mock_rotation_handler_class
+  end
+
+  def mock_rotation_error_handler_class(instance:)
+    mock_rotation_handler_class = Minitest::Mock.new
+    mock_rotation_handler_class.expect(:new, instance, [FakeRotatable, :value, StandardError, String, Hash])
+    mock_rotation_handler_class.expect(:!, false) # For presence checks
+    3.times { mock_rotation_handler_class.expect(:is_a?, false, [Symbol]) }
+
+    mock_rotation_handler_class
+  end
+end


### PR DESCRIPTION
Allow attributes to opt into key rotations. This is done by providing
some additional arguments to the `attr_encrypted` call in a model.
`attr_encrypted` needs to know the new key, old key, and logic by which
key rotation is to take place.

The new key should be specified as the `key:` argument. The old key is
specified by the `old_key:` argument. The key rotaion logic is contained
by a class constant specified by the `rotation_handler:` argument.

```ruby
attr_encrypted(
  :my_attribute,
  key: <new key>,
  old_key: <previous key>,
  rotation_handler: MyRotationHandler,
  rotation_error_handler: MyRotationErrorHandler,
  ...
)
```

The rotation handler class MUST:

1. have a constructor which accepts an instance of an active record
   model being rotated, a symbol of the name of the attribute being
   rotated, the value of the attribute, the value of the value of the
   attribute encrypted with the old key, a hash of the evaluated
   attr_encrypted_options (the options passed to the `attr_encrypted`
   call in the ActiveRecord model class.)
2. have a `#call` instance method which performs the rotation logic for
   the instance, attribute, etc passed in the constructor. Be mindful of
   transaction and locking boundaries in your custom logic to avoid race
   conditions.

An example:

```ruby
class RotationHandler
  def initialize(record, attribute_name, value, old_encrypted_value, options)
    self.attribute_name = attribute_name
    self.old_encrypted_value = old_encrypted_value
    self.options = options
    self.record = record
    self.value = value
  end

  def call
    record.with_lock do
      # record old encrypted value for historical purposes

      record.update_column(
        "encrypted_#{attribute_name}",
        record.encrypt(attribute_name.to_sym, value)
      )

      # record that rotation has succeeded for this record's attribute
    end
  rescue => e
    # record that rotation has failed for this record's attribute
  end

  private

  attr_accessor(
    :attribute_name,
    :old_encrypted_value,
    :options,
    :record,
    :value
  )
end
```

The rotation error handler class MUST:

1. have a constructor which accepts an instance of an active record
   model being rotated, a symbol of the name of the attribute being
   rotated, the value of the attribute, the error instance raised during
   the rotation, the value of the attribute encrypted with the old key, a
   hash of the evaluated attr_encrypted_options (the options passed to the
   `attr_encrypted` call in the ActiveRecord model class.)
2. have a `#call` instance method which performs the handling logic for
   the instance, attribute, etc passed in the constructor.

An Example:

```ruby
module NitroAttrEncrypted
  class RotationErrorHandler
    def initialize(record, attribute_name, error, encrypted_value, options)
      self.attribute_name = attribute_name
      self.error = error
      self.encrypted_value = encrypted_value
      self.options = options
      self.record = record
    end

    def call
      # Application specific logic to capture
      # rotation error information
    end

  private

    attr_accessor(
      :attribute_name,
      :error,
      :encrypted_value,
      :options,
      :record,
      :value
    )
  end
end
```